### PR TITLE
Adapt samples for Bluemix usage

### DIFF
--- a/com.ibm.streamsx.dps/impl/Makefile
+++ b/com.ibm.streamsx.dps/impl/Makefile
@@ -49,6 +49,7 @@ HELPER_LIBS += $(AERO_LIB)
 endif
 
 DISTRIBUTED_PROCESS_STORE_LIB = $(LIB)/libDistributedProcessStoreLib.so
+DISTRIBUTED_PROCESS_STORE_LIB_STATIC = $(LIB)/libDistributedProcessStoreLibStatic.a
 
 SPL_PKGCFG = $(STREAMS_INSTALL)/bin/dst-pe-pkg-config.sh
 SPL_PKG = dst-spl-pe-install
@@ -84,7 +85,7 @@ vpath %.cpp src
 
 export CPLUS_INCLUDE_PATH=./include:./ext/include:$JAVA_HOME/include:$JAVA_HOME/include/linux
 
-all: check-streams $(DISTRIBUTED_PROCESS_STORE_LIB) $(HELPER_LIBS)
+all: check-streams $(DISTRIBUTED_PROCESS_STORE_LIB_STATIC) $(DISTRIBUTED_PROCESS_STORE_LIB) $(HELPER_LIBS)
 
 check-streams:
 	@echo "Checking to see if STREAMS_INSTALL is set..."
@@ -93,6 +94,10 @@ check-streams:
 $(DISTRIBUTED_PROCESS_STORE_LIB): $(DISTRIBUTED_PROCESS_STORE_OBJS)
 	mkdir -p $(LIB)
 	$(CXX) $(LDFLAGS) -o $@ $^
+
+$(DISTRIBUTED_PROCESS_STORE_LIB_STATIC): $(DISTRIBUTED_PROCESS_STORE_OBJS)
+	mkdir -p $(LIB)
+	ar rcs $@ $^
 
 $(AERO_LIB): $(AERO_OBJ)
 	mkdir -p $(LIB)

--- a/com.ibm.streamsx.dps/impl/src/DistributedProcessStore.cpp
+++ b/com.ibm.streamsx.dps/impl/src/DistributedProcessStore.cpp
@@ -172,6 +172,7 @@ namespace distributed
     void* handle = NULL;
     std::string  kvLibName =  "";
     std::string toolkitDir = ProcessingElement::pe().getToolkitDirectory("com.ibm.streamsx.dps")  + "/impl/ext/lib" ;
+    std::string toolkitLibDir = ProcessingElement::pe().getToolkitDirectory("com.ibm.streamsx.dps")  + "/impl/lib" ;
     std::string streamsLibDir = SPL::Functions::Utility::getEnvironmentVariable("STREAMS_INSTALL") + "/ext/lib" ;
 	if (noSqlKvStoreProductName.compare("memcached") == 0) {
 		// reset method below is part of the C++ std::auto_ptr class.
@@ -219,8 +220,10 @@ namespace distributed
 		SPLAPPTRC(L_ERROR, error, "DistributedProcessStore");
 		throw(SPL::SPLRuntimeException("DistributedProcessStore::connectToDatabase", error));
 	}
-//	cout << "Going to load " << kvLibName << endl;
-	handle = dlopen(kvLibName.c_str(), RTLD_NOW|RTLD_GLOBAL);
+
+	std::string secondLevelLib = toolkitLibDir + "/" + kvLibName;
+    //std::cout << "load level2 lib : " << secondLevelLib << "\n";
+	handle = dlopen(secondLevelLib.c_str(), RTLD_NOW|RTLD_GLOBAL);
 	if (handle == NULL) {
 	      std::string error = "Cannot initialize libraries for chosen database " + noSqlKvStoreProductName + ", error message: ";
 	      error.append(dlerror());

--- a/samples/DPSUsageFromCpp/Makefile
+++ b/samples/DPSUsageFromCpp/Makefile
@@ -24,16 +24,17 @@
 
 DPS_TOOLKIT_HOME ?= $(STREAMS_INSTALL)/toolkits/com.ibm.streamsx.dps
 
-SPLC_FLAGS ?= -a -z -t $(DPS_TOOLKIT_HOME)
+SPLC_FLAGS ?= -a -t $(DPS_TOOLKIT_HOME)
 SPLC = $(STREAMS_INSTALL)/bin/sc
 SPL_CMD_ARGS ?= --data-directory=./data 
 SPL_MAIN_COMPOSITE = com.ibm.streamsx.dps.demo::Main
+OUTPUT_DIRECTORY = ./output/Main/Distributed
 
 all: distributed
 
 distributed:
-	$(SPLC) $(SPLC_FLAGS) -M $(SPL_MAIN_COMPOSITE) $(SPL_CMD_ARGS) --output-directory=./output/Main/Distributed
+	$(SPLC) $(SPLC_FLAGS) -M $(SPL_MAIN_COMPOSITE) $(SPL_CMD_ARGS) --output-directory=$(OUTPUT_DIRECTORY)
 
 clean: 
-	$(SPLC) $(SPLC_FLAGS) -C -M $(SPL_MAIN_COMPOSITE)
+	$(SPLC) $(SPLC_FLAGS) -C -M $(SPL_MAIN_COMPOSITE) --output-directory=$(OUTPUT_DIRECTORY)
 

--- a/samples/DPSUsageFromCpp/com.ibm.streamsx.dps.demo/Main.spl
+++ b/samples/DPSUsageFromCpp/com.ibm.streamsx.dps.demo/Main.spl
@@ -56,7 +56,7 @@ composite Main {
 		//data is read from filesource but could easily be any other adapter
 		stream<rstring id, float64 amount>  Data = FileSource(){
 			param
-				file: "transactions.txt";
+				file: getApplicationDir() + "/data/transactions.txt";
 		}		
 		
 		stream<rstring storeName>  TransactionSink = Transactions(Data) {

--- a/samples/DPSUsageFromCpp/com.ibm.streamsx.dps.demo/Transactions/Transactions.xml
+++ b/samples/DPSUsageFromCpp/com.ibm.streamsx.dps.demo/Transactions/Transactions.xml
@@ -7,11 +7,14 @@
         <library>
           <cmn:description/>
           <cmn:managedLibrary>
-			<cmn:lib>DistributedProcessStoreLib</cmn:lib><!-- This library contains the DPS functions -->
-			<!-- add the path to the other dependent libraries used by the DPS toolkit -->
-            <cmn:libPath>@STREAMS_INSTALL@/toolkits/com.ibm.streamsx.dps/impl/lib</cmn:libPath>
-            <cmn:libPath>@STREAMS_INSTALL@/toolkits/com.ibm.streamsx.dps/impl/ext/lib</cmn:libPath>
-            <cmn:includePath>@STREAMS_INSTALL@/toolkits/com.ibm.streamsx.dps/impl/include/</cmn:includePath>
+			<!-- This entry needs to load the DPS top level library 'libDistributedProcessStoreLib' from location of the toolkit -->
+			
+			<!-- option 1 : copy the shared version of the lib to the local impl/lib directory, so it gets packaged with the .sab file -->
+<!--		<cmn:command>../../impl/bin/archLevel</cmn:command>		-->
+			
+			<!-- option 2 : link against the static version of the library -->
+			<cmn:command>../../impl/bin/archLevelStatic</cmn:command>
+  
           </cmn:managedLibrary>
         </library>
       </libraryDependencies>

--- a/samples/DPSUsageFromCpp/impl/bin/archLevel
+++ b/samples/DPSUsageFromCpp/impl/bin/archLevel
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# determine the location of the DPS toolkit
+# use: export DPS_TOOLKIT_HOME=/some/path
+# before compilation to point to a different location than the default, which is the toolkit included in Streams
+DPS_TOOLKIT_HOME=${DPS_TOOLKIT_HOME:-$STREAMS_INSTALL/toolkits/com.ibm.streamsx.dps}
+
+# the directory of the script
+BASEDIR=$( cd $(dirname $0) ; pwd -P )
+
+if [ "$1" == "libPath" ]; then
+	# copy the top level lib to our impl/lib directory to have it bundled within the SAB file
+	mkdir -p $BASEDIR/../lib
+	cp $DPS_TOOLKIT_HOME/impl/lib/libDistributedProcessStoreLib.so $BASEDIR/../lib
+	echo ../../impl/lib
+
+elif [ "$1" == "includePath" ]; then
+	echo $DPS_TOOLKIT_HOME/impl/include
+
+elif [ "$1" == "lib" ]; then
+	echo DistributedProcessStoreLib
+
+else
+	echo "unsupported option"
+fi

--- a/samples/DPSUsageFromCpp/impl/bin/archLevelStatic
+++ b/samples/DPSUsageFromCpp/impl/bin/archLevelStatic
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# determine the location of the DPS toolkit
+# use: export DPS_TOOLKIT_HOME=/some/path
+# before compilation to point to a different location than the default, which is the toolkit included in Streams
+DPS_TOOLKIT_HOME=${DPS_TOOLKIT_HOME:-$STREAMS_INSTALL/toolkits/com.ibm.streamsx.dps}
+
+if [ "$1" == "libPath" ]; then
+	echo $DPS_TOOLKIT_HOME/impl/lib
+
+elif [ "$1" == "includePath" ]; then
+	echo $DPS_TOOLKIT_HOME/impl/include
+
+elif [ "$1" == "lib" ]; then
+	echo DistributedProcessStoreLibStatic
+
+else
+	echo "unsupported option"
+fi

--- a/samples/DPSUsageFromCpp/info.xml
+++ b/samples/DPSUsageFromCpp/info.xml
@@ -13,4 +13,7 @@
      <common:version>[2.0.0,4.0.0)</common:version>
    </info:toolkit>
  </info:dependencies>
+<info:sabFiles>
+   <info:include path="data/*"/>
+</info:sabFiles>
 </info:toolkitInfoModel>

--- a/samples/DPSUsageFromSPL/Makefile
+++ b/samples/DPSUsageFromSPL/Makefile
@@ -24,16 +24,17 @@
 
 DPS_TOOLKIT_HOME ?= $(STREAMS_INSTALL)/toolkits/com.ibm.streamsx.dps
 
-SPLC_FLAGS ?= -a -z -t $(DPS_TOOLKIT_HOME)
+SPLC_FLAGS ?= -a -t $(DPS_TOOLKIT_HOME)
 SPLC = $(STREAMS_INSTALL)/bin/sc
 SPL_CMD_ARGS ?= --data-directory=./data 
 SPL_MAIN_COMPOSITE = application::LastKnownLocation
+OUTPUT_DIRECTORY = ./output/LastKnownLocation/Distributed
 
 all: distributed
 
 distributed:
-	$(SPLC) $(SPLC_FLAGS) -M $(SPL_MAIN_COMPOSITE) $(SPL_CMD_ARGS) --output-directory=./output/LastKnownLocation/Distributed
+	$(SPLC) $(SPLC_FLAGS) -M $(SPL_MAIN_COMPOSITE) $(SPL_CMD_ARGS) --output-directory=$(OUTPUT_DIRECTORY)
 
 clean: 
-	$(SPLC) $(SPLC_FLAGS) -C -M $(SPL_MAIN_COMPOSITE)
+	$(SPLC) $(SPLC_FLAGS) -C -M $(SPL_MAIN_COMPOSITE) --output-directory=$(OUTPUT_DIRECTORY)
 

--- a/samples/DPSUsageFromSPL/application/LastKnownLocation.spl
+++ b/samples/DPSUsageFromSPL/application/LastKnownLocation.spl
@@ -18,7 +18,7 @@
 // PROFITS, BUSINESS INTERRUPTION, LOSS OF PROGRAMS OR OTHER DATA   
 // ON YOUR INFORMATION HANDLING SYSTEM OR OTHERWISE.                
 //                                                                  
-// (C) Copyright IBM Corp. 2016  All Rights reserved.         
+// (C) Copyright IBM Corp. 2017  All Rights reserved.         
 //                                                                  
 // end_generated_IBM_copyright_prolog                               
 namespace application;
@@ -31,8 +31,9 @@ use com.ibm.streamsx.lock.distributed::* ;
 /**This sample demonstrates the use of the DPS toolkit to store and retreive data.
  * The data is real taxi data from over 200 Taxis generally in and around London on December 31, 2013. 
  * The data is found in the file data/taxiLocationData within this project.
-* One part of the application receives taxi location data and saves it in a NoSQL back end  using the DPS toolkit
+ * One part of the application receives taxi location data and saves it in a NoSQL back end  using the DPS toolkit
  * Another part of the application responds to queries of taxi location by id and returns the last known data for the taxi.
+ * The results are printed in the logs and are written to the file /tmp/foundTaxis.txt
  */
 
 
@@ -48,7 +49,7 @@ type
 		stream< rstring taxi_Id, float64 latitude, float64 longitude, int64 timeStamp> RawData = FileSource()
 		{
 			param
-				file : "input/taxiLocationData.txt" ;
+				file : getApplicationDir() + "/data/input/taxiLocationData.txt" ;
 				format : csv ;
 		}
 
@@ -58,7 +59,7 @@ type
 			FileSource()
 		{
 			param
-				file : "input/taxiSearchQueries.txt" ;
+				file : getApplicationDir() + "/data/input/taxiSearchQueries.txt" ;
 				initDelay : 5.0 ;
 				format : csv ;
 		}
@@ -136,7 +137,7 @@ type
 		() as QueryAnswerWriter = FileSink(FoundTaxis)
 		{
 			param
-				file : "results/foundTaxis.txt" ;
+				file : "/tmp/foundTaxis.txt" ;
 				format : csv ;
 				flush : 1u ;
 				quoteStrings: false;

--- a/samples/DPSUsageFromSPL/info.xml
+++ b/samples/DPSUsageFromSPL/info.xml
@@ -12,4 +12,7 @@
       <common:version>[2.0.0,4.0.0)</common:version>
     </info:toolkit>
   </info:dependencies>
+<info:sabFiles>
+   <info:include path="data/**"/>
+</info:sabFiles>
 </info:toolkitInfoModel>


### PR DESCRIPTION
related to issue #38 

Adapted the DPSUsageFromSPL and DPSUsageFromCpp samples to run on Bluemix.
For the libDistributedProcessStoreLib.so library there is also a static version generated now : libDistributedProcessStoreLibStatic.a 
The second level libs (libDPSRedis.so, etc) are loaded with full path now.

